### PR TITLE
fix marker position in landscape mode

### DIFF
--- a/Sources/TouchTracker/Cocoa/TouchTrackingUIView.swift
+++ b/Sources/TouchTracker/Cocoa/TouchTrackingUIView.swift
@@ -177,6 +177,8 @@ public class TouchTrackingUIView: UIView {
             window.center = .init(x: location.x + offset.x,
                                 y: location.y + offset.y)
             window.windowScene = self.window?.windowScene
+            // WORKAROUND: Apply changes of orientation
+            window.rootViewController = .init()
             window.isHidden = false
         }
     }


### PR DESCRIPTION
Sometimes, when in landscape mode, the x and y coordinates of the marker may be inverted.