### PR TITLE
fix to release point windows when keyboard is displayed

### DIFF
--- a/Sources/TouchTracker/Cocoa/TouchTrackingUIView.swift
+++ b/Sources/TouchTracker/Cocoa/TouchTrackingUIView.swift
@@ -164,7 +164,7 @@ public class TouchTrackingUIView: UIView {
             pointWindows[touches.count..<pointWindows.count].forEach {
                 $0.isHidden = true
                 $0.windowScene = nil
-                $0.removeFromSuperview()
+                $0.uiviewRemoveFormSuperView()
             }
             pointWindows = Array(pointWindows[0..<touches.count])
         }

--- a/Sources/TouchTracker/Extension/UIWindow+.swift
+++ b/Sources/TouchTracker/Extension/UIWindow+.swift
@@ -76,4 +76,10 @@ extension UIWindow {
     }
 }
 
+extension UIWindow {
+    func uiviewRemoveFormSuperView() {
+        super.removeFromSuperview()
+    }
+}
+
 #endif


### PR DESCRIPTION
closes #28 

`removeFromSuperView` method is customized in `UIWindow`.
Therefore, fix to call the original method of UIView